### PR TITLE
Simplify filtering of site array using `includes`

### DIFF
--- a/source/index.blade.php
+++ b/source/index.blade.php
@@ -64,10 +64,10 @@ new Vue({
         type: 'all',
     },
     computed: {
-        filteredSites: function () {
-            if (this.type === 'all') return this.sites;
-
-            return this.sites.filter(site => !! site.types.find(type => type == this.type));
+        filteredSites() {
+            return this.type === 'all' ?
+                this.sites :
+                this.sites.filter(site => site.types.includes(this.type));
         }
     }
 }).$mount('#websites');


### PR DESCRIPTION
Since `sites` is an array, I think it's a little clearer and more expressive to use `includes` rather than `find` when filtering.